### PR TITLE
chore(deps): run husky as a prepare script instead of postinstall.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Simple plugin for adding Slash Command support in your existing bot.**
 
-[![GitHub](https://img.shields.io/github/license/sapphire/interactions)](https://github.com/sapphire/interactions/blob/main/LICENSE.md)
+[![GitHub](https://img.shields.io/github/license/sapphiredev/interactions)](https://github.com/sapphiredev/interactions/blob/main/LICENSE.md)
 [![codecov](https://codecov.io/gh/sapphiredev/interactions/branch/main/graph/badge.svg?token=pAvXhtqMu8)](https://codecov.io/gh/sapphiredev/interactions)
 [![npm](https://img.shields.io/npm/v/@sapphire/interactions?color=crimson&logo=npm&style=flat-square)](https://www.npmjs.com/package/@sapphire/interactions)
 [![Depfu](https://badges.depfu.com/badges/b7a32a808429b51ac55624f31f8a698d/overview.svg)](https://depfu.com/github/sapphiredev/interactions?project_id=23003)

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
 		"format": "prettier --write {src,tests}/**/*.ts",
 		"lint": "eslint src tests --ext ts --fix",
 		"postbuild": "run-p esm:*",
-		"postinstall": "husky install .github/husky",
 		"postpublish": "pinst --enable",
+		"prepare": "husky install .github/husky",
 		"prepublishOnly": "yarn build && pinst --disable",
 		"sversion": "standard-version",
 		"test:watch": "jest --watch",
@@ -81,7 +81,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/sapphire/interactions.git"
+		"url": "git+https://github.com/sapphiredev/interactions.git"
 	},
 	"files": [
 		"dist",
@@ -101,7 +101,7 @@
 		"discordjs"
 	],
 	"bugs": {
-		"url": "https://github.com/sapphire/interactions/issues"
+		"url": "https://github.com/sapphiredev/interactions/issues"
 	},
 	"homepage": "https://sapphiredev.github.io/interactions",
 	"commitlint": {


### PR DESCRIPTION
* Also updates Sapphire Github links to the new org name